### PR TITLE
can't download yui_compressor (404)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "http://rubygems.org"
+
+# Specify your gem's dependencies in rb-notifu.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,33 @@
+PATH
+  remote: .
+  specs:
+    juicer (1.0.9)
+      cmdparse
+      nokogiri
+      rubyzip
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    cmdparse (2.0.3)
+    fakefs (0.3.2)
+    git (1.2.5)
+    jeweler (1.6.0)
+      bundler (~> 1.0.0)
+      git (>= 1.2.5)
+      rake
+    mocha (0.9.12)
+    nokogiri (1.4.4.1-x86-mingw32)
+    rake (0.9.0)
+    rubyzip (0.9.4)
+    shoulda (2.11.3)
+
+PLATFORMS
+  x86-mingw32
+
+DEPENDENCIES
+  fakefs (>= 0.2.1)
+  jeweler (>= 0.2.1)
+  juicer!
+  mocha (>= 0.9.8)
+  shoulda (>= 2.10.2)

--- a/lib/juicer/install/yui_compressor_installer.rb
+++ b/lib/juicer/install/yui_compressor_installer.rb
@@ -13,6 +13,7 @@ module Juicer
       def initialize(install_dir = Juicer.home)
         super(install_dir)
         @latest = nil
+        @href = nil
         @website = "http://yuilibrary.com/downloads/"
       end
 
@@ -28,7 +29,7 @@ module Juicer
       def install(version = nil)
         version = super(version)
         base = "yuicompressor-#{version}"
-        filename = download(File.join(@website, "yuicompressor", "#{base}.zip"))
+        filename = download(@href)
         target = File.join(@install_dir, path)
 
         Zip::ZipFile.open(filename) do |file|
@@ -60,7 +61,9 @@ module Juicer
       def latest
         return @latest if @latest
         webpage = Nokogiri::HTML(open(@website))
-        @latest = (webpage / "h3#yuicompressor + ul li a:last").text.match(/(\d\.\d\.\d)/)[1]
+        a = (webpage / "h3#yuicompressor + ul li a:last")[0]
+        @href = a["href"]
+        @latest = a.text.match(/(\d\.\d\.\d)/)[1]
       end
     end
   end


### PR DESCRIPTION
``` bash
$ bundle exec juicer install yui_compressor
Installing Yui Compressor 2.4.6 in C:/Users/Slavic/.juicer/lib/yui_compressor
Downloading http://yuilibrary.com/downloads/yuicompressor/yuicompressor-2.4.6.zip
...open-uri.rb:346:in `open_http': 404 Not Found (OpenURI::HTTPError)
```

current download url is http://yui.zenfs.com/releases/yuicompressor/yuicompressor-2.4.6.zip
