### PR TITLE
Wasn't working in Rackspace Cloud Centos 5.6

### DIFF
--- a/lib/juicer/install/rhino_installer.rb
+++ b/lib/juicer/install/rhino_installer.rb
@@ -49,7 +49,7 @@ module Juicer
 
       def latest
         return @latest if @latest
-        webpage = Nokogiri::HTML(open(@website))
+        webpage = Nokogiri::HTML(open(@website).read)
         versions = (webpage / "td a").to_a.find_all { |a| a.attr("href") =~ /rhino\d_/ }
         @latest = versions.collect { |n| n.attr("href") }.sort.last.match(/rhino(\d_.*)\.zip/)[1]
       end

--- a/lib/juicer/install/yui_compressor_installer.rb
+++ b/lib/juicer/install/yui_compressor_installer.rb
@@ -60,7 +60,7 @@ module Juicer
       #
       def latest
         return @latest if @latest
-        webpage = Nokogiri::HTML(open(@website))
+        webpage = Nokogiri::HTML(open(@website).read)
         a = webpage.css('#downloads #dl_list ul li:first a').first
         @href = a['href']
         @latest = a.text.match(/\d\.\d\.\d/)[0]


### PR DESCRIPTION
Added a .read to the open(@website) command to in order to full get the html string.  
