### PR TITLE
Force images to embed with --force-image-embed cli parameter

### DIFF
--- a/lib/juicer/command/merge.rb
+++ b/lib/juicer/command/merge.rb
@@ -31,6 +31,7 @@ module Juicer
         @local_hosts = []               # Host names that are served from :document_root
         @verify = true                  # Verify js files with JsLint
 				@image_embed_type = :none       # Embed images in css files, options are :none, :data_uri
+        @force_image_embed = false
 
         @log = log || Logger.new(STDOUT)
 
@@ -84,6 +85,7 @@ the compressor the path should be the path to where the jar file is found.
                            (" " * 37) + "None leaves URLs untouched. Candiate images must be flagged with '?embed=true to be considered") do |embed|
             @image_embed_type = [:none, :data_uri].include?(embed.to_sym) ? embed.to_sym : nil
           end
+          opt.on("", "--force-image-embed", "Will force all images to embed without having to tag with embed parameter") { @force_image_embed = true }
         end
       end
 
@@ -193,7 +195,7 @@ the compressor the path should be the path to where the jar file is found.
 			# 
 			def image_embed(file)
         return nil if !file || file !~ /\.css$/ || @image_embed_type.nil?
-        Juicer::ImageEmbed.new(:document_root => @document_root, :type => @image_embed_type )
+        Juicer::ImageEmbed.new(:document_root => @document_root, :type => @image_embed_type, :force => @force_image_embed )
 			end
 
       #

--- a/lib/juicer/image_embed.rb
+++ b/lib/juicer/image_embed.rb
@@ -33,6 +33,7 @@ module Juicer
       @hosts = options[:hosts]
       @path_resolver = Juicer::Asset::PathResolver.new(:document_root => options[:document_root],
                                                        :hosts => options[:hosts])
+      @force = options[:force]
     end
 
     #
@@ -68,7 +69,7 @@ module Juicer
 
           if new_path.length < SIZE_LIMIT
             # replace the url in the css file with the data uri
-            @contents.gsub!(asset.path, embed_data_uri(asset.filename)) if asset.filename.match( /\?embed=true$/ )
+            @contents.gsub!(asset.path, embed_data_uri(asset.filename)) if @force || asset.filename.match( /\?embed=true$/ )
           else
             Juicer::LOGGER.warn("The final data uri for the image located at #{asset.path.gsub('?embed=true', '')} exceeds #{SIZE_LIMIT} and will not be embedded to maintain compatability.") 
           end
@@ -86,7 +87,12 @@ module Juicer
     def embed_data_uri( path )
       new_path = path
       
-      supported_file_matches = path.match( /(?:\.)(png|gif|jpg|jpeg)(?:\?embed=true)$/i )
+      if @force
+        supported_file_matches = path.match( /(?:\.)(png|gif|jpg|jpeg)$/i )
+      else
+        supported_file_matches = path.match( /(?:\.)(png|gif|jpg|jpeg)(?:\?embed=true)$/i )
+      end
+
       filetype = supported_file_matches[1] if supported_file_matches
       
       if ( filetype )        


### PR DESCRIPTION
This adds a command line option `--force-image-embed` which will force Juicer to embed images in CSS regardless of the `?embed=true` parameter.

My use case for this is wanting to merge and embed images in CSS files based upon dependencies I don't have control over. For example, I'm using jQuery Mobile in an app, I want to force Juicer to embed all of the jQuery mobile images but would prefer not to edit the jQuery Mobile CSS after each update to the framework.

I believe this force option makes sense considering the user is opting into it.
