### PR TITLE
Added CDN url for YUI compressor download. Fixes #61

### DIFF
--- a/lib/juicer/install/yui_compressor_installer.rb
+++ b/lib/juicer/install/yui_compressor_installer.rb
@@ -15,6 +15,7 @@ module Juicer
         @latest = nil
         @href = nil
         @website = 'https://github.com/yui/yuicompressor/downloads'
+        @cdn = 'http://cloud.github.com'
       end
 
       #
@@ -29,7 +30,7 @@ module Juicer
       def install(version = nil)
         version = super(version)
         base = "yuicompressor-#{version}"
-        filename = download(@href)
+        filename = download(@cdn+@href)
         target = File.join(@install_dir, path)
 
         Zip::ZipFile.open(filename) do |file|


### PR DESCRIPTION
This fixes the issue with YUI not installing correctly.
The problem arises due to github redirecting several times and the download script getting confused.  This defines the URL of github's CDN so there's less redirecting, which solves the problem.

After installing this fix, ~/.juicer/download/yui_compressor and ~/.juicer/lib/yui_compressor must be deleted before running `juicer install yui_compressor`, as juicer may already think yui_compressor is installed.
