### PR TITLE
Fixes some UTF-8 ArgumentErrors I was getting with the regular expression in Ruby 1.9.3

### DIFF
--- a/lib/juicer/dependency_resolver/css_dependency_resolver.rb
+++ b/lib/juicer/dependency_resolver/css_dependency_resolver.rb
@@ -12,7 +12,7 @@ module Juicer
 
     private
     def parse(line, imported_file = nil)
-      return $2 if line =~ @@import_pattern
+      return $2 if encoded_line(line) =~ @@import_pattern
 
       # At first sight of actual CSS rules we abort (TODO: This does not take
       # into account the fact that rules may be commented out and that more

--- a/lib/juicer/dependency_resolver/dependency_resolver.rb
+++ b/lib/juicer/dependency_resolver/dependency_resolver.rb
@@ -58,6 +58,14 @@ module Juicer
       raise NotImplementedError.new
     end
 
+    def encoded_line(line)
+      if String.method_defined?(:encode)
+        line.encode!('UTF-8', 'UTF-8', :invalid => :replace)
+      else
+        line
+      end
+    end
+
     #
     # Carries out the actual work of resolve. resolve resets the internal
     # file list and yields control to _resolve for rebuilding the file list.

--- a/lib/juicer/dependency_resolver/javascript_dependency_resolver.rb
+++ b/lib/juicer/dependency_resolver/javascript_dependency_resolver.rb
@@ -9,7 +9,7 @@ module Juicer
 
     private
     def parse(line, imported_file = nil)
-      return $1 if line =~ @@depends_pattern
+      return $1 if encoded_line(line) =~ @@depends_pattern
 
       # If we have already skimmed through some @depend/@depends or a
       # closing comment we're done.

--- a/test/unit/juicer/dependency_resolver/css_dependency_resolver_test.rb
+++ b/test/unit/juicer/dependency_resolver/css_dependency_resolver_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "test_helper"
 
 class TestCssDependencyResolver < Test::Unit::TestCase
@@ -32,5 +33,13 @@ class TestCssDependencyResolver < Test::Unit::TestCase
   def test_load_order
     files = @resolver.resolve(path("a1.css")).collect { |file| file.split("/").pop }
     assert_equal "d1.cssb1.cssc1.cssa1.css", files.join
+  end
+
+  def test_parse
+    text = "© Dynamic Drive"
+    text.force_encoding("us-ascii") if RUBY_VERSION > "1.9"
+    assert_nothing_raised ArgumentError do
+      @resolver.send(:parse, text)
+    end
   end
 end

--- a/test/unit/juicer/dependency_resolver/javascript_dependency_resolver_test.rb
+++ b/test/unit/juicer/dependency_resolver/javascript_dependency_resolver_test.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "test_helper"
 
 class TestJavaScriptDependencyResolver < Test::Unit::TestCase
@@ -46,5 +47,13 @@ class TestJavaScriptDependencyResolver < Test::Unit::TestCase
 
     actual_files = @resolver.resolve(my_app)
     assert_equal expected_files, actual_files
+  end
+
+  def test_parse
+    text = "© Dynamic Drive"
+    text.force_encoding("us-ascii") if RUBY_VERSION > "1.9"
+    assert_nothing_raised ArgumentError do
+      @resolver.send(:parse, text)
+    end
   end
 end


### PR DESCRIPTION
The encoding cannot be guaranteed in the file source read in from
IO.foreach.
