### PR TITLE
Fix for URL's with regex chars

### DIFF
--- a/lib/juicer/merger/stylesheet_merger.rb
+++ b/lib/juicer/merger/stylesheet_merger.rb
@@ -59,7 +59,7 @@ module Juicer
         content.scan(/url\([\s"']*([^\)"'\s]*)[\s"']*\)/m).uniq.collect do |url|
           url = url.first
           path = resolve_path(url, dir)
-          content.gsub!(/\([\s"']*#{url}[\s"']*\)/m, "(#{path})") unless path == url
+          content.gsub!(/\([\s"']*#{Regexp.escape(url)}[\s"']*\)/m, "(#{path})") unless path == url
         end
 
         content


### PR DESCRIPTION
Escaping the replaced url before using it as a regex search avoids unsafe characters breaking the replacing of the old URL with the new URL. This was discovered with font file urls containing ".eot?#iefix". The '?' character was being interpreted as a regular expression when attempting to replace the old URL with the newly qualified path. Because of this the URL was not being updated in the output file.
