### PR TITLE
Cache buster works with Font Awesome files

### DIFF
--- a/lib/juicer/cache_buster.rb
+++ b/lib/juicer/cache_buster.rb
@@ -84,7 +84,7 @@ module Juicer
       type = [:soft, :hard, :rails, :md5].include?(type) ? type : :soft
       parameter = nil if type == :rails
       file = self.clean(file, parameter)
-      filename = file.split("?").first
+      filename = file.split(/[\?\#]/).first
       raise ArgumentError.new("#{file} could not be found") unless File.exists?(filename)
       mtime = File.mtime(filename).to_i
 
@@ -95,10 +95,10 @@ module Juicer
         return "#{file}#{file.index('?') ? '' : "?#{mtime}"}"
       elsif type == :md5
         md5 = Digest::MD5.hexdigest(File.read(filename))
-        return file.sub(/(\.[^\.]+$)/, "-#{parameter}#{md5}" + '\1')
+        return file.sub(/(\.[^\.]+([\?\#].*)?$)/, "-#{parameter}#{md5}" + '\1')
       end
 
-      file.sub(/(\.[^\.]+$)/, "-#{parameter}#{mtime}" + '\1')
+      file.sub(/(\.[^\.]+([\?\#].*)?$)/, "-#{parameter}#{mtime}" + '\1')
     end
 
     #

--- a/test/unit/juicer/asset/path_test.rb
+++ b/test/unit/juicer/asset/path_test.rb
@@ -144,6 +144,18 @@ class AssetPathTest < Test::Unit::TestCase
         md5 = Digest::MD5.hexdigest(File.read(@filename))
         assert_equal "/#{@filename.sub(/\.txt/, '')}-jcb#{md5}.txt", @asset.absolute_path(:cache_buster => :jcb, :cache_buster_type => :md5)
       end
+
+      should "works with #fontawesomeregular?v=3.2.1 in URL" do
+        filename = "tmp.asset.txt"
+        file = File.open(@filename, "w") { |f| f.puts "Testing" }
+        md5 = Digest::MD5.hexdigest(File.read(filename))
+
+        suffix = '#fontawesomeregular?v=3.2.1'
+        filename_with_suffix = "#{filename}#{suffix}"
+        asset = Juicer::Asset::Path.new filename_with_suffix, :document_root => Dir.pwd
+
+        assert_equal "/#{filename_with_suffix.sub(".txt#{suffix}", '')}-jcb#{md5}.txt#{suffix}", asset.absolute_path(:cache_buster => :jcb, :cache_buster_type => :md5)
+      end
     end
   end
 


### PR DESCRIPTION
#  Cache buster works with Font Awesome files

Adding md5 cache busters to Font Awesome (http://fontawesome.io/) results in urls that are broken.
This pull request fixes this. I can now run unmodified font awesome css files through juicer.

This could also be fixed by modifying the original css files but maintenance would be easier for me if I could use the original files.

I tested this also with hard and soft cache busters and they work.
Using rails cache buster, nothing is added to the url, it uses the original url. Is this expected?
## Original

../font/fontawesome-webfont.eot?v=3.2.1
../font/fontawesome-webfont.eot?#iefix&v=3.2.1
## Result

../font/fontawesome-webfont.eot?v=3.2-jcb5ae23ad29b67289a1375d2043e289c52.1
../font/fontawesome-webfont.eot?#iefix&v=3.2-jcb5ae23ad29b67289a1375d2043e289c52.1
## Expected result

../font/fontawesome-webfont-jcb5ae23ad29b67289a1375d2043e289c52.eot?v=3.2.1
../font/fontawesome-webfont-jcb5ae23ad29b67289a1375d2043e289c52.eot?#iefix&v=3.2.1
