### PR TITLE
Fixed the relocation of ClosureCompiler from GoogleCode to Github

### DIFF
--- a/lib/juicer/install/closure_compiler_installer.rb
+++ b/lib/juicer/install/closure_compiler_installer.rb
@@ -13,8 +13,8 @@ module Juicer
       def initialize(install_dir = Juicer.home)
         super(install_dir)
         @latest = nil
-        @website = "http://code.google.com/p/closure-compiler/downloads/list"
-        @download_link = "http://closure-compiler.googlecode.com/files/compiler-%s.zip"
+        @website = "https://github.com/google/closure-compiler/releases"
+        @download_link = "http://dl.google.com/closure-compiler/compiler-%s.zip"
       end
 
       #
@@ -33,7 +33,7 @@ module Juicer
         target = File.join(@install_dir, path)
 
         Zip::ZipFile.open(filename) do |file|
-          file.extract("README", File.join(target, version, "README"))
+          file.extract("README.md", File.join(target, version, "README"))
           file.extract("compiler.jar", File.join(target, "bin", "#{base}.jar"))
         end
       end
@@ -60,7 +60,7 @@ module Juicer
       def latest
         return @latest if @latest
         webpage = Nokogiri::HTML(open(@website).read)
-        @latest = (webpage / "//table[@id='resultstable']//td/a[contains(@href, 'compiler')]").map{|link|
+        @latest = (webpage / "//div[@class='release-timeline']//h3/a[contains(@href, 'compiler')]").map{|link|
           link.get_attribute('href')[/\d{8}/].to_i
         }.sort.last.to_s
       end


### PR DESCRIPTION
Hi there,

Google decided to move away from Google Code and place a redirect to Github on the Closure release page. I've change the URLs and the Version detection to work with Github and Download still uses the Google DL location.

Current Error:

```
vagrant@vagrant-acc84d66:~$ juicer install closure_compiler
/usr/lib/ruby/1.9.1/open-uri.rb:216:in `open_loop': redirection forbidden: http://code.google.com/p/closure-compiler/downloads/list -> https://code.google.com/archive/p/closure-compiler/downloads (RuntimeError)
    from /usr/lib/ruby/1.9.1/open-uri.rb:146:in `open_uri'
    from /usr/lib/ruby/1.9.1/open-uri.rb:677:in `open'
    from /usr/lib/ruby/1.9.1/open-uri.rb:33:in `open'
    from /var/lib/gems/1.9.1/gems/juicer-1.2.0/lib/juicer/install/closure_compiler_installer.rb:62:in `latest'
    from /var/lib/gems/1.9.1/gems/juicer-1.2.0/lib/juicer/command/install.rb:57:in `version'
    from /var/lib/gems/1.9.1/gems/juicer-1.2.0/lib/juicer/command/install.rb:42:in `block in execute'
    from /var/lib/gems/1.9.1/gems/juicer-1.2.0/lib/juicer/command/install.rb:39:in `each'
    from /var/lib/gems/1.9.1/gems/juicer-1.2.0/lib/juicer/command/install.rb:39:in `execute'
    from /var/lib/gems/1.9.1/gems/cmdparse-2.0.6/lib/cmdparse.rb:464:in `parse'
    from /var/lib/gems/1.9.1/gems/juicer-1.2.0/lib/juicer/cli.rb:27:in `parse'
    from /var/lib/gems/1.9.1/gems/juicer-1.2.0/lib/juicer/cli.rb:37:in `run'
    from /var/lib/gems/1.9.1/gems/juicer-1.2.0/bin/juicer:6:in `<top (required)>'
    from /usr/local/bin/juicer:23:in `load'
    from /usr/local/bin/juicer:23:in `<main>'
```

Cheers,
Jan
